### PR TITLE
Fix release check writing multi-line value to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,11 @@ jobs:
       - name: Check if release already exists
         id: check_release
         run: |
-          RELEASE_EXISTS=$(gh release view ${{ github.ref_name }} 2>/dev/null && echo "true" || echo "false")
-          echo "exists=$RELEASE_EXISTS" >> $GITHUB_OUTPUT
+          if gh release view ${{ github.ref_name }} &>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The check_release step was capturing `gh release view` output (multi-line) into a variable and writing it to GITHUB_OUTPUT with a plain echo. Newer GitHub Actions runners reject multi-line values in GITHUB_OUTPUT without the heredoc format, causing the step to fail on any re-triggered workflow run where a release already exists.

Replaced command substitution with a simple if/else so only "true" or "false" is written.

https://claude.ai/code/session_019TW5nzDmSS1E2CXFrY4e3K